### PR TITLE
Create config.lua

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,1 @@
+mpackage = "vyzor"


### PR DESCRIPTION
This fixes an issue where without an explicit package name, Mudlet has to use the zip name for the package name - thus the latest released "Vyzor-3.3.3.zip" gets imported as "vyzor-333". This subsequently breaks vyzor loader, which expects the folder name to be called ``vyzor`` in ``pcall(require, "vyzor")`` so it can find ``init.lua`` within.

Fixes #3.