### PR TITLE
Fix MiniConsole:DEcho to correctly send to self

### DIFF
--- a/component/mini_console.lua
+++ b/component/mini_console.lua
@@ -365,11 +365,8 @@ local function new (_, _name, initialX, initialY, initialWidth, initialHeight, i
 
   --- Displays text on a MiniConsole with some crazy-ass formatting.
   -- @string text
-  -- @param foregroundColor The foreground color of the text.
-  -- @param backgroundColor The background color of the text.
-  -- @bool useInsertText If true, uses InsertText() instead of echo().
-  function self:DEcho (text, foregroundColor, backgroundColor, useInsertText)
-    decho(text, foregroundColor, backgroundColor, useInsertText, _name)
+  function self:DEcho (text)
+    decho(_name, text)
   end
 
   --- Displays a clickable line of text in a MiniConsole.


### PR DESCRIPTION
Also, decho supports only 2 params: [console name], text. The colors are expected as part of the text in the form <FR,FG,FB:BR,BG,BB>. For interoperability with ansi2decho, remove additional params in MiniConsole:DEcho